### PR TITLE
CP4I LTS version fixes

### DIFF
--- a/ibm-products/cp4i/deploy-cp4i.sh
+++ b/ibm-products/cp4i/deploy-cp4i.sh
@@ -83,7 +83,7 @@ ES_OPERATOR_CHANNEL="v3.2"
 # Operations Dashboard
 OD_CASE_VERSION="2.6.11"
 OD_CATALOG_IMAGE="icr.io/cpopen/ibm-integration-operations-dashboard-catalog@sha256:756c4e3aa31c9ee9641dcdac89566d8f3a78987160d75ab010a7e0eadb91a873"
-OD_OPERATOR_CHANNEL="v2.6"
+OD_OPERATOR_CHANNEL="v2.6-lts"
 
 # Automation Assets
 AA_CASE_VERSION="1.5.9"

--- a/ibm-products/cp4i/deploy-cp4i.sh
+++ b/ibm-products/cp4i/deploy-cp4i.sh
@@ -47,6 +47,59 @@ log-output "INFO: Workspace directory is set to : $WORKSPACE_DIR"
 log-output "INFO: Binary directory is set to : $BIN_DIR"
 log-output "INFO: Temp directory is set to : $TMP_DIR"
 
+# Catalog and operator details
+
+# Platform UI + Common Services
+PN_CASE_VERSION="1.7.10"
+PN_CATALOG_IMAGE="icr.io/cpopen/ibm-integration-platform-navigator-catalog@sha256:3435a5d0e2375d0524bd3baaa0dad772280efe6cacc13665ac8b2760ad3ebb35"
+PN_OPERATOR_CHANNEL="v6.0"
+CS_CASE_VERSION="1.15.12"
+CS_CATALOG_IMAGE="icr.io/cpopen/ibm-common-service-catalog@sha256:fbf8ef961f3ff3c98ca4687f5586741ea97085ab5b78691baa056a5d581eecf5"
+CS_OPERATOR_CHANNEL="v3.19"
+
+# APIC
+APIC_CASE_VERSION="4.0.4"
+APIC_CATALOG_IMAGE="icr.io/cpopen/ibm-apiconnect-catalog@sha256:a89b72f4794b74caec423059d0551660951c9d772d9892789d3bdf0407c3f61a"
+APIC_OPERATOR_CHANNEL="v3.3"
+
+# App Connect
+APPCONNECT_CASE_VERSION="5.0.7"
+APPCONNECT_CATALOG_IMAGE="icr.io/cpopen/appconnect-operator-catalog@sha256:ccb9190be75128376f64161dccfb6d64915b63207206c9b74d05611ab88125ce"
+APPCONNECT_OPERATOR_CHANNEL="v5.0-lts"
+
+# Aspera + Redis
+ASPERA_CASE_VERSION="1.5.8"
+ASPERA_CATALOG_IMAGE="icr.io/cpopen/aspera-hsts-catalog@sha256:ba2b97642692c627382e738328ec5e4b566555dcace34d68d0471439c1efc548"
+ASPERA_OPERATOR_CHANNEL="v1.5"
+REDIS_CASE_VERSION="1.6.6"
+REDIS_CATALOG_IMAGE="icr.io/cpopen/ibm-cloud-databases-redis-catalog@sha256:fddf96636005a9c276aec061a3b514036ce6d79bd91fd7e242126b2f52394a78"
+#REDIS_OPERATOR_CHANNEL=""  
+
+# Event Streams
+ES_CASE_VERSION="3.2.0"
+ES_CATALOG_IMAGE="icr.io/cpopen/ibm-eventstreams-catalog@sha256:ac87cfecba0635a67c7d9b6c453c752cba9b631ffdd340223e547809491eb708"
+ES_OPERATOR_CHANNEL="v3.2"
+
+# Operations Dashboard
+OD_CASE_VERSION="2.6.11"
+OD_CATALOG_IMAGE="icr.io/cpopen/ibm-integration-operations-dashboard-catalog@sha256:756c4e3aa31c9ee9641dcdac89566d8f3a78987160d75ab010a7e0eadb91a873"
+OD_OPERATOR_CHANNEL="v2.6"
+
+# Automation Assets
+AA_CASE_VERSION="1.5.9"
+AA_CATALOG_IMAGE="icr.io/cpopen/ibm-integration-asset-repository-catalog@sha256:1af42da7f7c8b12818d242108b4db6f87862504f1c57789213539a98720b0fed"
+AA_OPERATOR_CHANNEL="v1.5"
+
+# DataPower
+DATAPOWER_CASE_VERSION="1.6.7"
+DATAPOWER_CATALOG_IMAGE="icr.io/cpopen/datapower-operator-catalog@sha256:1b3e967cfa0c4615ad183ba0f19cca5f64fbad9eb833ee5dad9b480b38d80010"
+DATAPOWER_OPERATOR_CHANNEL="v1.6"
+
+# MQ
+MQ_CASE_VERSION="2.0.12"
+MQ_CATALOG_IMAGE="icr.io/cpopen/ibm-mq-operator-catalog@sha256:ea21ed79f877458392ac160a358f72a4b33c755220f5d9eaccfdb89ab2232a3b"
+MQ_OPERATOR_CHANNEL="v2.0"
+
 ######
 # Create working directories
 mkdir -p ${WORKSPACE_DIR}
@@ -124,8 +177,8 @@ metadata:
   name: ibm-apiconnect-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "APIC Operators 4.10"
-  image: icr.io/cpopen/ibm-apiconnect-catalog@sha256:e3950b6d9c2f86ec1be3deb6db1cb2e479592c3d288de94fe239fa9d01e6d445
+  displayName: "APIC from CASE ${APIC_CASE_VERSION}"
+  image: ${APIC_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -150,8 +203,8 @@ metadata:
   name: ibm-appconnect-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "ACE Operators 7.0.0"
-  image: icr.io/cpopen/appconnect-operator-catalog@sha256:89d67d6a6934f056705000855bac890f6699435a475b690c143387a5c6a1352c
+  displayName: "App Connect from CASE ${APPCONNECT_CASE_VERSION}"
+  image: ${APPCONNECT_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -176,8 +229,8 @@ metadata:
   name: ibm-aspera-hsts-operator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "Aspera Operators latest"
-  image: icr.io/cpopen/aspera-hsts-catalog@sha256:a1c401135c5a4a9f3c88e2ac9b75299b9be376d6f97f34d7f68f2a31f0c726cd
+  displayName: "Aspera from CASE ${ASPERA_CASE_VERSION}"
+  image: ${ASPERA_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -202,8 +255,8 @@ metadata:
   name: ibm-cloud-databases-redis-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "Redis for Aspera Operators 1.6.2"
-  image: icr.io/cpopen/ibm-cloud-databases-redis-catalog@sha256:68dfcc9bb5b39990171c30e20fee337117c7385a07c4868efd28751d15e08e9f
+  displayName: "Redis from CASE ${REDIS_CASE_VERSION}"
+  image: ${REDIS_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -228,8 +281,8 @@ metadata:
   name: ibm-common-service-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "IBMCS Operators v3.22.0"
-  image: icr.io/cpopen/ibm-common-service-catalog@sha256:36c410c39a52c98919f22f748e67f7ac6d3036195789d9cfbcd8a362dedbb2bd
+  displayName: "IBM Foundation Services from CASE ${CS_CASE_VERSION}"
+  image: ${CS_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -245,7 +298,7 @@ wait_for_catalog ibm-common-service-catalog
 log-output "INFO: Catalog source ibm-common-service-catalog is ready"
 
 if [[ -z $(${BIN_DIR}/oc get catalogsource -n openshift-marketplace | grep ibm-datapower-operator-catalog) ]]; then
-    log-output "INFO: Installing IBM Data Power catalog source"
+    log-output "INFO: Installing IBM DataPower catalog source"
     if [[ -f ${WORKSPACE_DIR}/data-power-catalogsource.yaml ]]; then rm ${WORKSPACE_DIR}/data-power-catalogsource.yaml; fi
     cat << EOF >> ${WORKSPACE_DIR}/data-power-catalogsource.yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -254,8 +307,8 @@ metadata:
   name: ibm-datapower-operator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "DP Operators 1.6.5"
-  image: icr.io/cpopen/datapower-operator-catalog@sha256:244827e90e194fc92e0d60d5da7ec434d2711139ea1392f816a05bde83da386a
+  displayName: "DataPower from CASE ${DATAPOWER_CASE_VERSION}"
+  image: ${DATAPOWER_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -264,7 +317,7 @@ spec:
 EOF
     ${BIN_DIR}/oc create -f ${WORKSPACE_DIR}/data-power-catalogsource.yaml
 else
-    log-output "INFO: IBM Data Power catalog source already installed"
+    log-output "INFO: IBM DataPower catalog source already installed"
 fi
 
 wait_for_catalog ibm-datapower-operator-catalog
@@ -280,8 +333,8 @@ metadata:
   name: ibm-eventstreams-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "ES Operators v3.1.3"
-  image: icr.io/cpopen/ibm-eventstreams-catalog@sha256:803f7f8de9d3e2d52878ec78da6991917cfe21af937ab39009e2f218bf6ac0a1
+  displayName: "Event Streams from CASE ${ES_CASE_VERSION}"
+  image: ${ES_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -306,8 +359,8 @@ metadata:
   name: ibm-integration-asset-repository-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "AR Operators 1.5.4"
-  image: icr.io/cpopen/ibm-integration-asset-repository-catalog@sha256:89cd0b2bfc66241cfaf542de906982434c23d1c6391db72fc6ef99d851568abe
+  displayName: "Automation Assets from CASE ${AA_CASE_VERSION}"
+  image: ${AA_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -332,8 +385,8 @@ metadata:
   name: ibm-integration-operations-dashboard-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "OD Operators 2.6.6"
-  image: icr.io/cpopen/ibm-integration-operations-dashboard-catalog@sha256:adca1ed1a029ec648c665e9e839da3a7d20e533809706b72e7e676c665d2d7b3
+  displayName: "Operations Dashboard from CASE ${OD_CASE_VERSION}"
+  image: ${OD_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -358,8 +411,8 @@ metadata:
   name: ibm-integration-platform-navigator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "PN Operators 7.0.0"
-  image: icr.io/cpopen/ibm-integration-platform-navigator-catalog@sha256:d98a7858cef16b558969d8cb5490f0916e89ad8fd4ca5baa0ce20580ccf9bef6
+  displayName: "CP4I from CASE ${PN_CASE_VERSION}"
+  image: ${PN_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -384,8 +437,8 @@ metadata:
   name: ibm-mq-operator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: "MQ Operators v2.2.1"
-  image: icr.io/cpopen/ibm-mq-operator-catalog@sha256:8de83ff5531de8df3ca639f612480f95ccd39a26e85a1bbdf18c7375dc93917a
+  displayName: "MQ from CASE ${MQ_CASE_VERSION}"
+  image: ${MQ_CATALOG_IMAGE}
   publisher: IBM
   sourceType: grpc
   updateStrategy:
@@ -439,6 +492,7 @@ spec:
   name: ibm-common-service-operator
   source: ibm-common-service-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${CS_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/common-services-sub.yaml
 else
@@ -485,6 +539,7 @@ spec:
   name: ibm-integration-platform-navigator
   source: ibm-integration-platform-navigator-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${PN_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/platform-navigator-subscription.yaml
 else
@@ -508,6 +563,7 @@ spec:
   name: aspera-hsts-operator
   source: ibm-aspera-hsts-operator-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${ASPERA_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/aspera-subscription.yaml
 else
@@ -531,6 +587,7 @@ spec:
   name: ibm-appconnect
   source: ibm-appconnect-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${APPCONNECT_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/app-connect-subscription.yaml
 else
@@ -554,6 +611,7 @@ spec:
   name: ibm-eventstreams
   source: ibm-eventstreams-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${ES_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/event-streams-subscription.yaml
 else
@@ -577,6 +635,7 @@ spec:
   name: ibm-mq
   source: ibm-mq-operator-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${MQ_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/mq-subscription.yaml
 else
@@ -600,6 +659,7 @@ spec:
   name: ibm-integration-asset-repository
   source: ibm-integration-asset-repository-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${AA_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/asset-repo-subscription.yaml
 else
@@ -609,9 +669,9 @@ fi
 wait_for_subscription ${NAMESPACE} ibm-integration-asset-repository-ibm-integration-asset-repository-catalog-openshift-marketplace 15
 log-output "INFO: IBM Integration Asset Repository subscription ready"
 
-# Data power
+# DataPower
 if [[ -z $(${BIN_DIR}/oc get subscriptions -n ${NAMESPACE} | grep datapower-operator-ibm-datapower-operator-catalog-openshift-marketplace) ]]; then
-    log-output "INFO: Creating subscription for IBM Data Power"
+    log-output "INFO: Creating subscription for IBM DataPower"
     if [[ -f ${WORKSPACE_DIR}/data-power-subscription.yaml ]]; then rm ${WORKSPACE_DIR}/data-power-subscription.yaml; fi
     cat << EOF >> ${WORKSPACE_DIR}/data-power-subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -623,14 +683,15 @@ spec:
   name: datapower-operator
   source: ibm-datapower-operator-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${DATAPOWER_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/data-power-subscription.yaml
 else
-    log-output "INFO: IBM Data Power subscription already exists"
+    log-output "INFO: IBM DataPower subscription already exists"
 fi
 
 wait_for_subscription ${NAMESPACE} datapower-operator-ibm-datapower-operator-catalog-openshift-marketplace 15
-log-output "INFO: IBM Data Power subscription ready"
+log-output "INFO: IBM DataPower subscription ready"
 
 # API Connect
 if [[ -z $(${BIN_DIR}/oc get subscriptions -n ${NAMESPACE} | grep ibm-apiconnect-ibm-apiconnect-catalog-openshift-marketplace) ]]; then
@@ -646,6 +707,7 @@ spec:
   name: ibm-apiconnect
   source: ibm-apiconnect-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${APIC_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/api-connect-subscription.yaml
 else
@@ -669,6 +731,7 @@ spec:
   name: ibm-integration-operations-dashboard
   source: ibm-integration-operations-dashboard-catalog
   sourceNamespace: openshift-marketplace
+  channel: ${OD_OPERATOR_CHANNEL}
 EOF
     ${BIN_DIR}/oc create -n ${NAMESPACE} -f ${WORKSPACE_DIR}/ops-dashboard-subscription.yaml
 else

--- a/ibm-products/cp4i/deploy-cp4i.sh
+++ b/ibm-products/cp4i/deploy-cp4i.sh
@@ -55,7 +55,7 @@ PN_CATALOG_IMAGE="icr.io/cpopen/ibm-integration-platform-navigator-catalog@sha25
 PN_OPERATOR_CHANNEL="v6.0"
 CS_CASE_VERSION="1.15.12"
 CS_CATALOG_IMAGE="icr.io/cpopen/ibm-common-service-catalog@sha256:fbf8ef961f3ff3c98ca4687f5586741ea97085ab5b78691baa056a5d581eecf5"
-CS_OPERATOR_CHANNEL="v3.19"
+CS_OPERATOR_CHANNEL="v3"
 
 # APIC
 APIC_CASE_VERSION="4.0.4"


### PR DESCRIPTION
 - Update deploy script to use variables for all CASE, catalog image and operator channel information
 - Update deploy script to use these variables, changing the versions of operators to match what we expect for 2022.2.1
 - Correct some usage of DataPower naming
 
 Tested by running the script against a fresh ARO cluster  - LTS PN stood up with all LTS versions of operators installed
 